### PR TITLE
Put the client configuration into the database.

### DIFF
--- a/application.yaml
+++ b/application.yaml
@@ -7,10 +7,13 @@ spring:
         username:
         password:
 trackr:
-    pageRedirectUris: http://localhost/trackr/authorize
+    oauth:
+        resourceId: techdev-services
+        webClientId: trackr-page
     apiUrl: http://localhost/trackr/api
 techdev:
     portal:
+        clientId: techdev-portal
         base-url: /portal/
         accessTokenUri: http://localhost/portal/oauth/token
         trackr:

--- a/src/main/java/de/techdev/portal/core/OauthAuthorizationServerConfiguration.java
+++ b/src/main/java/de/techdev/portal/core/OauthAuthorizationServerConfiguration.java
@@ -26,7 +26,7 @@ public class OauthAuthorizationServerConfiguration extends AuthorizationServerCo
 
     @Bean
     public ApprovalStore approvalStore() {
-            return new JdbcApprovalStore(dataSource);
+        return new JdbcApprovalStore(dataSource);
     }
 
     @Bean

--- a/src/main/java/de/techdev/portal/core/OauthAuthorizationServerConfiguration.java
+++ b/src/main/java/de/techdev/portal/core/OauthAuthorizationServerConfiguration.java
@@ -1,7 +1,6 @@
 package de.techdev.portal.core;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.config.annotation.configurers.ClientDetailsServiceConfigurer;
@@ -21,16 +20,6 @@ import javax.sql.DataSource;
 @Configuration
 @EnableAuthorizationServer
 public class OauthAuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
-
-    public static final String TRACKR_RESOURCE_ID = "techdev-services";
-    public static final String TRACKR_PAGE_CLIENT = "trackr-page";
-    public static final String TECHDEV_PORTAL_CLIENT = "techdev-portal";
-
-    @Value("${trackr.pageRedirectUris}")
-    private String trackrPageRedirectUris;
-
-    @Value("${techdev.portal.trackr.clientSecret}")
-    private String portalTrackrClientSecret;
 
     @Autowired
     private DataSource dataSource;
@@ -52,20 +41,7 @@ public class OauthAuthorizationServerConfiguration extends AuthorizationServerCo
 
     @Override
     public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
-        clients.inMemory()
-                .withClient(TRACKR_PAGE_CLIENT)
-                    .resourceIds(TRACKR_RESOURCE_ID)
-                    .authorizedGrantTypes("authorization_code", "implicit") //TODO: what to set here?
-                    .authorities("ROLE_CLIENT")
-                    .scopes("read", "write")
-                    .redirectUris(trackrPageRedirectUris.split(","))
-                .and()
-                .withClient(TECHDEV_PORTAL_CLIENT)
-                    .resourceIds(TRACKR_RESOURCE_ID)
-                    .authorizedGrantTypes("client_credentials")
-                    .authorities("ROLE_ADMIN")
-                    .scopes("read", "write")
-                    .secret(portalTrackrClientSecret);
+        clients.jdbc(dataSource);
     }
 
     @Override

--- a/src/main/java/de/techdev/portal/domain/trackr/TrackrConfiguration.java
+++ b/src/main/java/de/techdev/portal/domain/trackr/TrackrConfiguration.java
@@ -12,10 +12,10 @@ import static java.util.Arrays.asList;
 class TrackrConfiguration {
 
     @Value("${trackr.oauth.resourceId}")
-    private String trackrResourceId = "techdev-services";
+    private String trackrResourceId;
 
     @Value("${techdev.portal.clientId}")
-    private String techdevPortalClientId = "techdev-portal";
+    private String techdevPortalClientId;
 
     @Value("${techdev.portal.accessTokenUri}")
     private String accessTokenUri;

--- a/src/main/java/de/techdev/portal/domain/trackr/TrackrConfiguration.java
+++ b/src/main/java/de/techdev/portal/domain/trackr/TrackrConfiguration.java
@@ -1,6 +1,5 @@
 package de.techdev.portal.domain.trackr;
 
-import de.techdev.portal.core.OauthAuthorizationServerConfiguration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +11,12 @@ import static java.util.Arrays.asList;
 @Configuration
 class TrackrConfiguration {
 
+    @Value("${trackr.oauth.resourceId}")
+    private String trackrResourceId = "techdev-services";
+
+    @Value("${techdev.portal.clientId}")
+    private String techdevPortalClientId = "techdev-portal";
+
     @Value("${techdev.portal.accessTokenUri}")
     private String accessTokenUri;
 
@@ -21,8 +26,8 @@ class TrackrConfiguration {
     @Bean
     public OAuth2RestTemplate trackrTemplate() {
         ClientCredentialsResourceDetails resourceDetails = new ClientCredentialsResourceDetails();
-        resourceDetails.setId(OauthAuthorizationServerConfiguration.TRACKR_RESOURCE_ID);
-        resourceDetails.setClientId(OauthAuthorizationServerConfiguration.TECHDEV_PORTAL_CLIENT);
+        resourceDetails.setId(trackrResourceId);
+        resourceDetails.setClientId(techdevPortalClientId);
         resourceDetails.setAccessTokenUri(accessTokenUri);
         resourceDetails.setClientSecret(trackrClientSecret);
         resourceDetails.setScope(asList("read", "write"));

--- a/src/main/java/de/techdev/portal/domain/user/update/TokenDeleter.java
+++ b/src/main/java/de/techdev/portal/domain/user/update/TokenDeleter.java
@@ -1,16 +1,18 @@
 package de.techdev.portal.domain.user.update;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
 
-import static de.techdev.portal.core.OauthAuthorizationServerConfiguration.TRACKR_PAGE_CLIENT;
-
 @Service
 class TokenDeleter {
+
+    @Value("${trackr.oauth.webClientId}")
+    private String trackrWebpageClientId = "trackr-page";
 
     @Autowired
     private TokenStore tokenStore;
@@ -19,7 +21,7 @@ class TokenDeleter {
      * Delete all access tokens for a user belonging to the trackr page client.
      */
     void deleteTrackrAngularClientTokens(String username) {
-        Collection<OAuth2AccessToken> tokens = tokenStore.findTokensByClientIdAndUserName(TRACKR_PAGE_CLIENT, username);
+        Collection<OAuth2AccessToken> tokens = tokenStore.findTokensByClientIdAndUserName(trackrWebpageClientId, username);
         for (OAuth2AccessToken token : tokens) {
             tokenStore.removeAccessToken(token);
         }

--- a/src/main/java/de/techdev/portal/domain/user/update/TokenDeleter.java
+++ b/src/main/java/de/techdev/portal/domain/user/update/TokenDeleter.java
@@ -12,7 +12,7 @@ import java.util.Collection;
 class TokenDeleter {
 
     @Value("${trackr.oauth.webClientId}")
-    private String trackrWebpageClientId = "trackr-page";
+    private String trackrWebpageClientId;
 
     @Autowired
     private TokenStore tokenStore;

--- a/src/main/resources/db/migration/V2__oauth_clients_table.sql
+++ b/src/main/resources/db/migration/V2__oauth_clients_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE oauth_client_details (
+  client_id VARCHAR(256) PRIMARY KEY,
+  resource_ids VARCHAR(256),
+  client_secret VARCHAR(256),
+  scope VARCHAR(256),
+  authorized_grant_types VARCHAR(256),
+  web_server_redirect_uri VARCHAR(256),
+  authorities VARCHAR(256),
+  access_token_validity INTEGER,
+  refresh_token_validity INTEGER,
+  additional_information VARCHAR(4096),
+  autoapprove VARCHAR(256)
+);


### PR DESCRIPTION
This makes our clients for resources configurable via the database instead of in memory.

The largest benefit will be to increase the token lifetime for trackr, because right now it's the default value and if you want to enter your times every day you have to login every day again. (Of course this can also be done in memory but the database config is cleaner anyway).

If merged we should discuss in which place we store the data for the table for our clients.
